### PR TITLE
fix: race condition on permission check API

### DIFF
--- a/internal/api/v1beta1/permission_check.go
+++ b/internal/api/v1beta1/permission_check.go
@@ -43,10 +43,8 @@ func (h Handler) CheckResourcePermission(ctx context.Context, req *shieldv1beta1
 	var results []*shieldv1beta1.CheckResourcePermissionResponse_ResourcePermissionResponse
 	checkCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	resultCh := make(chan resourcePermissionResult)
-	defer close(resultCh)
-	errorCh := make(chan error)
-	defer close(errorCh)
+	resultCh := make(chan resourcePermissionResult, len(req.ResourcePermissions))
+	errorCh := make(chan error, len(req.ResourcePermissions))
 
 	for _, permission := range req.ResourcePermissions {
 		go func(checkCtx context.Context, resourcePermission *shieldv1beta1.ResourcePermission,

--- a/internal/api/v1beta1/permission_check_test.go
+++ b/internal/api/v1beta1/permission_check_test.go
@@ -79,6 +79,22 @@ func TestHandler_CheckResourcePermission(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "Deprecated check single resource permission: should return unauthenticated error if relation service's CheckAuthz function returns auth error",
+			setup: func(res *mocks.ResourceService) {
+				res.EXPECT().CheckAuthz(mock.AnythingOfType("*context.emptyCtx"), resource.Resource{
+					Name:        testRelationV2.Object.ID,
+					NamespaceID: testRelationV2.Object.NamespaceID,
+				}, action.Action{ID: schema.EditPermission}).Return(false, user.ErrInvalidEmail)
+			},
+			request: &shieldv1beta1.CheckResourcePermissionRequest{
+				ObjectId:        testRelationV2.Object.ID,
+				ObjectNamespace: testRelationV2.Object.NamespaceID,
+				Permission:      schema.EditPermission,
+			},
+			want:    nil,
+			wantErr: grpcUnauthenticated,
+		},
+		{
 			name: "should return internal error if relation service's CheckAuthz function returns some error",
 			setup: func(res *mocks.ResourceService) {
 				res.EXPECT().CheckAuthz(mock.AnythingOfType("*context.emptyCtx"), resource.Resource{


### PR DESCRIPTION
- Removing close on the error chan and result chan in permission check API, as it can lead to race conditions.
- Making the unbuffered channel as buffered to avoid the forgotten sender. 

Ref:

- [The Forgotten Sender](https://betterprogramming.pub/common-goroutine-leaks-that-you-should-avoid-fe12d12d6ee)
- [Ok to leave the channel open ?](https://stackoverflow.com/questions/8593645/is-it-ok-to-leave-a-channel-open)
- [Close()](https://go.dev/tour/concurrency/4#:~:text=Another%20note%3A,Imports)