### PR TITLE
fix: list user api

### DIFF
--- a/internal/store/postgres/group_repository_test.go
+++ b/internal/store/postgres/group_repository_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/goto/salt/log"
+	"github.com/ory/dockertest"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/goto/shield/core/group"
 	"github.com/goto/shield/core/organization"
 	"github.com/goto/shield/core/relation"
@@ -16,8 +19,6 @@ import (
 	"github.com/goto/shield/internal/schema"
 	"github.com/goto/shield/internal/store/postgres"
 	"github.com/goto/shield/pkg/db"
-	"github.com/ory/dockertest"
-	"github.com/stretchr/testify/suite"
 )
 
 type GroupRepositoryTestSuite struct {
@@ -708,6 +709,50 @@ func (s *GroupRepositoryTestSuite) TestListGroupRelations() {
 					},
 					Subject: relation.Subject{
 						ID:        s.users[1].ID,
+						Namespace: schema.UserPrincipal,
+						RoleID:    "shield/group:member",
+					},
+				},
+				{
+					Object: relation.Object{
+						ID:          s.groups[0].ID,
+						NamespaceID: schema.GroupNamespace,
+					},
+					Subject: relation.Subject{
+						ID:        s.users[2].ID,
+						Namespace: schema.UserPrincipal,
+						RoleID:    "shield/group:member",
+					},
+				},
+				{
+					Object: relation.Object{
+						ID:          s.groups[0].ID,
+						NamespaceID: schema.GroupNamespace,
+					},
+					Subject: relation.Subject{
+						ID:        s.users[3].ID,
+						Namespace: schema.UserPrincipal,
+						RoleID:    "shield/group:member",
+					},
+				},
+				{
+					Object: relation.Object{
+						ID:          s.groups[0].ID,
+						NamespaceID: schema.GroupNamespace,
+					},
+					Subject: relation.Subject{
+						ID:        s.users[4].ID,
+						Namespace: schema.UserPrincipal,
+						RoleID:    "shield/group:member",
+					},
+				},
+				{
+					Object: relation.Object{
+						ID:          s.groups[0].ID,
+						NamespaceID: schema.GroupNamespace,
+					},
+					Subject: relation.Subject{
+						ID:        s.users[5].ID,
 						Namespace: schema.UserPrincipal,
 						RoleID:    "shield/group:member",
 					},

--- a/internal/store/postgres/testdata/mock-user.json
+++ b/internal/store/postgres/testdata/mock-user.json
@@ -14,5 +14,29 @@
                 "bar": "v2"
             }
         }
+    },
+    {
+        "name": "Alex Xu",
+        "email": "alex.xu@gotocompany.com"
+    },
+    {
+        "name": "Alexa Xu",
+        "email": "alexa@gotocompany.com",
+        "metadata": {
+            "k1": "value-string",
+            "k2": 123,
+            "k3": {
+                "foo": "v1",
+                "bar": "v2"
+            }
+        }
+    },
+    {
+        "name": "Bella Anto",
+        "email": "bella.anto@gotocompany.com"
+    },
+    {
+        "name": "Balex Ro",
+        "email": "balex.ro@gotocompany.com"
     }
 ]

--- a/internal/store/postgres/user_repository.go
+++ b/internal/store/postgres/user_repository.go
@@ -11,11 +11,12 @@ import (
 	"time"
 
 	"github.com/doug-martin/goqu/v9"
+	"github.com/jmoiron/sqlx"
+	newrelic "github.com/newrelic/go-agent"
+
 	"github.com/goto/shield/core/user"
 	"github.com/goto/shield/pkg/db"
 	"github.com/goto/shield/pkg/uuid"
-	"github.com/jmoiron/sqlx"
-	newrelic "github.com/newrelic/go-agent"
 )
 
 type UserRepository struct {
@@ -279,10 +280,20 @@ func (r UserRepository) List(ctx context.Context, flt user.Filter) ([]user.User,
 
 	query, params, err := dialect.From(TABLE_USERS).LeftOuterJoin(
 		goqu.T(TABLE_METADATA),
-		goqu.On(goqu.Ex{"users.id": goqu.I("metadata.user_id")})).Select("users.id", "name", "email", "key", "value", "users.created_at", "users.updated_at").Where(goqu.Or(
-		goqu.C("name").ILike(fmt.Sprintf("%%%s%%", flt.Keyword)),
-		goqu.C("email").ILike(fmt.Sprintf("%%%s%%", flt.Keyword)),
-	)).Limit(uint(flt.Limit)).Offset(uint(offset)).ToSQL()
+		goqu.On(goqu.Ex{"users.id": goqu.I("metadata.user_id")})).Select("users.id", "name", "email", "key", "value", "users.created_at", "users.updated_at").Where(
+		goqu.I("users.email").In(
+			goqu.From("users").
+				Select(goqu.DISTINCT("email")).
+				Where(
+					goqu.Or(
+						goqu.C("name").ILike(fmt.Sprintf("%%%s%%", flt.Keyword)),
+						goqu.C("email").ILike(fmt.Sprintf("%%%s%%", flt.Keyword)),
+					),
+				).
+				Limit(uint(flt.Limit)).
+				Offset(uint(offset)),
+		),
+	).ToSQL()
 	if err != nil {
 		return []user.User{}, fmt.Errorf("%w: %s", queryErr, err)
 	}


### PR DESCRIPTION
The exisitng query returns the rows from the LEFT JOIN of users table on metadata table. These rows selected might have more than one rows for a single user. Since the limit is set on these rows, it might result into lesser number of users returned after merging the metadata.

This PR fixes the query.