### PR TITLE
fix: lock goreleaser version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2.6.1
         with:
           distribution: goreleaser
-          version: latest
+          version: v1.26.2
           args: --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_TOKEN }}


### PR DESCRIPTION
Goreleaser has released version 2.0.0 which has some breaking changes. So, in this PR we are locking the version to v1.26.2.