### PR TITLE
fix: call partition procedure w/o a txn block

### DIFF
--- a/internal/store/postgres/migrations/20240603063345_partition_data_proc.up.sql
+++ b/internal/store/postgres/migrations/20240603063345_partition_data_proc.up.sql
@@ -1,5 +1,6 @@
-BEGIN TRANSACTION;
-
-  CALL partman.partition_data_proc('public.activities', p_batch := 100, p_source_table := 'public.old_activities');
-
-COMMIT;
+DO
+$$
+BEGIN
+    CALL partman.partition_data_proc('public.activities', p_batch := 100, p_source_table := 'public.old_activities');
+END;
+$$;

--- a/internal/store/postgres/migrations/20240603063345_partition_data_proc.up.sql
+++ b/internal/store/postgres/migrations/20240603063345_partition_data_proc.up.sql
@@ -1,6 +1,1 @@
-DO
-$$
-BEGIN
-    CALL partman.partition_data_proc('public.activities', p_batch := 100, p_source_table := 'public.old_activities');
-END;
-$$;
+CALL partman.partition_data_proc('public.activities', p_batch := 100, p_source_table := 'public.old_activities');


### PR DESCRIPTION
wrapping in a transaction block gives `invalid transaction termination`