### PR TITLE
fix: fix CheckPermission API make fully_consistent

### DIFF
--- a/internal/store/spicedb/relation_repository.go
+++ b/internal/store/spicedb/relation_repository.go
@@ -108,6 +108,11 @@ func (r RelationRepository) Check(ctx context.Context, rel relation.Relation, ac
 	}
 
 	request := &authzedpb.CheckPermissionRequest{
+		Consistency: &authzedpb.Consistency{
+			Requirement: &authzedpb.Consistency_FullyConsistent{
+				FullyConsistent: true,
+			},
+		},
 		Resource:   relationship.Resource,
 		Subject:    relationship.Subject,
 		Permission: act.ID,


### PR DESCRIPTION
By default CheckPermission API behaviour is  ```Consistency { minimize_latency: true }``` because of this Check API is failing. 
To fix that need to update default behaviour and make it fully consistent
```Consistency { fully_consistent: true }```