### PR TITLE
fix: list project admins to fetch shield/project:owner role

### DIFF
--- a/internal/store/postgres/project_repository.go
+++ b/internal/store/postgres/project_repository.go
@@ -12,8 +12,8 @@ import (
 	"github.com/goto/shield/core/namespace"
 	"github.com/goto/shield/core/organization"
 	"github.com/goto/shield/core/project"
-	"github.com/goto/shield/core/role"
 	"github.com/goto/shield/core/user"
+	"github.com/goto/shield/internal/schema"
 	"github.com/goto/shield/pkg/db"
 	newrelic "github.com/newrelic/go-agent/v3/newrelic"
 	"go.nhat.io/otelsql"
@@ -412,7 +412,7 @@ func (r ProjectRepository) ListAdmins(ctx context.Context, projectID string) ([]
 			goqu.I("u.id").Cast("VARCHAR").Eq(goqu.I("r.subject_id")),
 		)).Where(goqu.Ex{
 		"r.object_id":            projectID,
-		"r.role_id":              role.DefinitionProjectAdmin.ID,
+		"r.role_id":              schema.GetRoleID(schema.ProjectNamespace, schema.OwnerRole),
 		"r.subject_namespace_id": namespace.DefinitionUser.ID,
 		"r.object_namespace_id":  namespace.DefinitionProject.ID,
 	}).ToSQL()


### PR DESCRIPTION
List Project Admins still checks old format `project_admin` role in relations table but shield creates `shield/project:owner `, `shield/project:viewer`, `shield/project:editor`  only default roles now. This is should ideally be checking `shield/project:owner ` relation in db to list Project admins.