### PR TITLE
fix: handle failedprecondition error

### DIFF
--- a/core/resource/service.go
+++ b/core/resource/service.go
@@ -413,6 +413,7 @@ func (s Service) ListUserResourcesByType(ctx context.Context, userID string, res
 	if err != nil {
 		switch status.Code(err) {
 		case codes.FailedPrecondition:
+			s.logger.Warn(err.Error())
 			return ResourcePermissions{}, ErrInvalidDetail
 		default:
 			return ResourcePermissions{}, err
@@ -449,6 +450,7 @@ func (s Service) ListAllUserResources(ctx context.Context, userID string, resour
 			if err != nil {
 				switch status.Code(err) {
 				case codes.FailedPrecondition:
+					s.logger.Warn(err.Error())
 					continue
 				default:
 					return map[string]ResourcePermissions{}, err
@@ -480,6 +482,7 @@ func (s Service) listUserResources(ctx context.Context, resourceType string, use
 		resources, err := s.relationService.LookupResources(ctx, resourceType, action, userNamespace, user.ID)
 		if err != nil {
 			if strings.Contains(err.Error(), "not found under definition") {
+				s.logger.Warn(err.Error())
 				continue
 			}
 			return ResourcePermissions{}, err

--- a/core/resource/service.go
+++ b/core/resource/service.go
@@ -481,6 +481,8 @@ func (s Service) listUserResources(ctx context.Context, resourceType string, use
 		actMap[action] = true
 		resources, err := s.relationService.LookupResources(ctx, resourceType, action, userNamespace, user.ID)
 		if err != nil {
+			// continue if permission under a namespace is not found
+			// https://github.com/authzed/spicedb/blob/main/internal/dispatch/graph/errors.go#L73
 			if strings.Contains(err.Error(), "not found under definition") {
 				s.logger.Warn(err.Error())
 				continue


### PR DESCRIPTION
Handle failed precondition error on list user resources. Case example: a resource type is stored in db but no longer exist in schema, this will return not found error. 