### PR TITLE
feat: use project uuid in resource project relation

### DIFF
--- a/core/resource/service.go
+++ b/core/resource/service.go
@@ -158,7 +158,7 @@ func (s Service) Upsert(ctx context.Context, res Resource) (Resource, error) {
 		return Resource{}, err
 	}
 
-	if err = s.AddProjectToResource(ctx, project.Project{ID: res.ProjectID}, newResource); err != nil {
+	if err = s.AddProjectToResource(ctx, project.Project{ID: newResource.ProjectID}, newResource); err != nil {
 		return Resource{}, err
 	}
 
@@ -216,7 +216,7 @@ func (s Service) Create(ctx context.Context, res Resource) (Resource, error) {
 		return Resource{}, err
 	}
 
-	if err = s.AddProjectToResource(ctx, project.Project{ID: res.ProjectID}, newResource); err != nil {
+	if err = s.AddProjectToResource(ctx, project.Project{ID: newResource.ProjectID}, newResource); err != nil {
 		return Resource{}, err
 	}
 

--- a/internal/api/v1beta1/resource_test.go
+++ b/internal/api/v1beta1/resource_test.go
@@ -163,6 +163,28 @@ func TestHandler_CreateResource(t *testing.T) {
 			wantErr: grpcBadBodyError,
 		},
 		{
+			name: "should return bad body error if project service return not exist error",
+			setup: func(ctx context.Context, rs *mocks.ResourceService, ps *mocks.ProjectService, rls *mocks.RelationService, _ *mocks.RelationTransformer) context.Context {
+				ps.EXPECT().Get(mock.AnythingOfType("*context.valueCtx"), testResource.ProjectID).Return(project.Project{}, project.ErrNotExist)
+				return user.SetContextWithEmail(ctx, email)
+			},
+			request: &shieldv1beta1.CreateResourceRequest{
+				Body: &shieldv1beta1.ResourceRequestBody{
+					Name:        testResource.Name,
+					ProjectId:   testResource.ProjectID,
+					NamespaceId: testResource.NamespaceID,
+					Relations: []*shieldv1beta1.Relation{
+						{
+							RoleName: "owner",
+							Subject:  "user:" + testUserID,
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: grpcBadBodyError,
+		},
+		{
 			name: "should return internal error if project service return some error",
 			setup: func(ctx context.Context, rs *mocks.ResourceService, ps *mocks.ProjectService, rls *mocks.RelationService, _ *mocks.RelationTransformer) context.Context {
 				ps.EXPECT().Get(mock.AnythingOfType("*context.valueCtx"), testResource.ProjectID).Return(project.Project{}, errors.New("some error"))
@@ -501,6 +523,22 @@ func TestHandler_UpdateResource(t *testing.T) {
 			name: "should return bad body error if request body is empty",
 			request: &shieldv1beta1.UpdateResourceRequest{
 				Id: testResourceID,
+			},
+			want:    nil,
+			wantErr: grpcBadBodyError,
+		},
+		{
+			name: "should return bad body error if project service return not exist error",
+			setup: func(rs *mocks.ResourceService, ps *mocks.ProjectService) {
+				ps.EXPECT().Get(mock.AnythingOfType("context.todoCtx"), testResource.ProjectID).Return(project.Project{}, project.ErrNotExist)
+			},
+			request: &shieldv1beta1.UpdateResourceRequest{
+				Id: testResourceID,
+				Body: &shieldv1beta1.ResourceRequestBody{
+					Name:        testResource.Name,
+					ProjectId:   testResource.ProjectID,
+					NamespaceId: testResource.NamespaceID,
+				},
 			},
 			want:    nil,
 			wantErr: grpcBadBodyError,


### PR DESCRIPTION
Shield created org and project relation with a resouce with user passed value. This allows creating relation with both slug and uuid. Later, when a permission at project level is checked, it tries to check using project uuid, but spicedb returns false. Fixing by making sure resource <> project relation use project uuid from db.